### PR TITLE
[FEAT] 홈페이지 추가 섹션 UI 구현

### DIFF
--- a/src/app/home/page.tsx
+++ b/src/app/home/page.tsx
@@ -17,7 +17,7 @@ const page = async () => {
         <div className="absolute inset-x-0 top-0 z-10">
           <Header />
         </div>
-        <div className="flex flex-col gap-9">
+        <div className="flex flex-col gap-9 pb-28">
           <TrendingSection />
           <div className="flex flex-col gap-6 pl-3">
             <PreviewSection />

--- a/src/app/home/page.tsx
+++ b/src/app/home/page.tsx
@@ -1,16 +1,11 @@
+import AnimationMoviesSection from "@/components/home/AnimationMoviesSection";
 import Header from "@/components/home/Header";
-import MediaCardSection from "@/components/home/MediaCardSection";
+import KoreanMoviesSection from "@/components/home/KoreanMoviesSection";
+import NetflixOriginalsSection from "@/components/home/NetflixOriginalsSection";
 import PreviewSection from "@/components/home/PreviewSection";
 import TrendingSection from "@/components/home/TrendingSection";
-import { getAnimationMovies, getKoreanMovies, getNetflixOriginals } from "@/lib/apis/tmdb";
 
 const page = async () => {
-  const [animationMovies, koreanMovies, netflixOriginals] = await Promise.all([
-    getAnimationMovies(),
-    getKoreanMovies(),
-    getNetflixOriginals(),
-  ]);
-
   return (
     <div>
       <div className="relative">
@@ -21,9 +16,9 @@ const page = async () => {
           <TrendingSection />
           <div className="flex flex-col gap-6 pl-3">
             <PreviewSection />
-            <MediaCardSection title="Netflix Originals" items={netflixOriginals.results} />
-            <MediaCardSection title="Animation Movies" items={animationMovies.results} />
-            <MediaCardSection title="Korean Movies" items={koreanMovies.results} />
+            <NetflixOriginalsSection />
+            <AnimationMoviesSection />
+            <KoreanMoviesSection />
           </div>
         </div>
       </div>

--- a/src/app/home/page.tsx
+++ b/src/app/home/page.tsx
@@ -5,7 +5,7 @@ import NetflixOriginalsSection from "@/components/home/NetflixOriginalsSection";
 import PreviewSection from "@/components/home/PreviewSection";
 import TrendingSection from "@/components/home/TrendingSection";
 
-const page = async () => {
+const page = () => {
   return (
     <div>
       <div className="relative">

--- a/src/app/home/page.tsx
+++ b/src/app/home/page.tsx
@@ -1,8 +1,16 @@
 import Header from "@/components/home/Header";
+import MediaCardSection from "@/components/home/MediaCardSection";
 import PreviewSection from "@/components/home/PreviewSection";
 import TrendingSection from "@/components/home/TrendingSection";
+import { getAnimationMovies, getKoreanMovies, getNetflixOriginals } from "@/lib/apis/tmdb";
 
-const page = () => {
+const page = async () => {
+  const [animationMovies, koreanMovies, netflixOriginals] = await Promise.all([
+    getAnimationMovies(),
+    getKoreanMovies(),
+    getNetflixOriginals(),
+  ]);
+
   return (
     <div>
       <div className="relative">
@@ -13,7 +21,9 @@ const page = () => {
           <TrendingSection />
           <div className="flex flex-col gap-6 pl-3">
             <PreviewSection />
-            {/* 하단 섹션들 추가*/}
+            <MediaCardSection title="Netflix Originals" items={netflixOriginals.results} />
+            <MediaCardSection title="Animation Movies" items={animationMovies.results} />
+            <MediaCardSection title="Korean Movies" items={koreanMovies.results} />
           </div>
         </div>
       </div>

--- a/src/components/home/AnimationMoviesSection.tsx
+++ b/src/components/home/AnimationMoviesSection.tsx
@@ -4,7 +4,7 @@ import { getAnimationMovies } from "@/lib/apis/tmdb";
 const AnimationMoviesSection = async () => {
   const data = await getAnimationMovies();
 
-  return <MediaCardSection title="Animation Movies" items={data.results} />;
+  return <MediaCardSection title="Animation Movies" items={data.results} size="small" />;
 };
 
 export default AnimationMoviesSection;

--- a/src/components/home/AnimationMoviesSection.tsx
+++ b/src/components/home/AnimationMoviesSection.tsx
@@ -1,0 +1,10 @@
+import MediaCardSection from "@/components/home/MediaCardSection";
+import { getAnimationMovies } from "@/lib/apis/tmdb";
+
+const AnimationMoviesSection = async () => {
+  const data = await getAnimationMovies();
+
+  return <MediaCardSection title="Animation Movies" items={data.results} />;
+};
+
+export default AnimationMoviesSection;

--- a/src/components/home/KoreanMoviesSection.tsx
+++ b/src/components/home/KoreanMoviesSection.tsx
@@ -1,0 +1,10 @@
+import MediaCardSection from "@/components/home/MediaCardSection";
+import { getKoreanMovies } from "@/lib/apis/tmdb";
+
+const KoreanMoviesSection = async () => {
+  const data = await getKoreanMovies();
+
+  return <MediaCardSection title="Korean Movies" items={data.results} />;
+};
+
+export default KoreanMoviesSection;

--- a/src/components/home/KoreanMoviesSection.tsx
+++ b/src/components/home/KoreanMoviesSection.tsx
@@ -4,7 +4,7 @@ import { getKoreanMovies } from "@/lib/apis/tmdb";
 const KoreanMoviesSection = async () => {
   const data = await getKoreanMovies();
 
-  return <MediaCardSection title="Korean Movies" items={data.results} />;
+  return <MediaCardSection title="Korean Movies" items={data.results} size="small" />;
 };
 
 export default KoreanMoviesSection;

--- a/src/components/home/MediaCardCarousel.tsx
+++ b/src/components/home/MediaCardCarousel.tsx
@@ -1,0 +1,43 @@
+"use client";
+
+import Image from "next/image";
+
+import { useDragScroll } from "@/lib/hooks/useDragScroll";
+import { TmdbMedia } from "@/types/tmdb";
+
+interface MediaCardCarouselProps {
+  items: TmdbMedia[];
+}
+
+const MediaCardCarousel = ({ items }: MediaCardCarouselProps) => {
+  const { ref, onMouseDown, onMouseMove, onMouseUp, onMouseLeave } = useDragScroll();
+
+  return (
+    <div
+      ref={ref}
+      onMouseDown={onMouseDown}
+      onMouseMove={onMouseMove}
+      onMouseUp={onMouseUp}
+      onMouseLeave={onMouseLeave}
+      className="flex cursor-pointer gap-1.75 overflow-hidden select-none"
+    >
+      {items.map(item => {
+        const title = item.media_type === "movie" ? item.title : item.name;
+
+        return (
+          <div key={item.id} className="relative h-[10rem] w-[6.4375rem] shrink-0 overflow-hidden">
+            <Image
+              src={`${process.env.NEXT_PUBLIC_IMAGE_BASE_URL}/t/p/w300${item.poster_path}`}
+              alt={title}
+              fill
+              sizes="120px"
+              className="pointer-events-none object-cover"
+            />
+          </div>
+        );
+      })}
+    </div>
+  );
+};
+
+export default MediaCardCarousel;

--- a/src/components/home/MediaCardCarousel.tsx
+++ b/src/components/home/MediaCardCarousel.tsx
@@ -22,7 +22,7 @@ const MediaCardCarousel = ({ items }: MediaCardCarouselProps) => {
       className="flex cursor-pointer gap-1.75 overflow-hidden select-none"
     >
       {items.map(item => {
-        const title = item.media_type === "movie" ? item.title : item.name;
+        const title = ("title" in item ? item.title : item.name) || "이미지 없음";
 
         return (
           <div key={item.id} className="relative h-[10rem] w-[6.4375rem] shrink-0 overflow-hidden">

--- a/src/components/home/MediaCardCarousel.tsx
+++ b/src/components/home/MediaCardCarousel.tsx
@@ -7,10 +7,13 @@ import { TmdbMedia } from "@/types/tmdb";
 
 interface MediaCardCarouselProps {
   items: TmdbMedia[];
+  size?: "small" | "large";
 }
 
-const MediaCardCarousel = ({ items }: MediaCardCarouselProps) => {
+const MediaCardCarousel = ({ items, size = "small" }: MediaCardCarouselProps) => {
   const { ref, onMouseDown, onMouseMove, onMouseUp, onMouseLeave } = useDragScroll();
+
+  const cardSize = size === "small" ? "w-[103px] h-[161px]" : "w-[154px] h-[251px]";
 
   return (
     <div
@@ -25,7 +28,10 @@ const MediaCardCarousel = ({ items }: MediaCardCarouselProps) => {
         const title = ("title" in item ? item.title : item.name) || "이미지 없음";
 
         return (
-          <div key={item.id} className="relative h-[10rem] w-[6.4375rem] shrink-0 overflow-hidden">
+          <div
+            key={item.id}
+            className={`relative shrink-0 overflow-hidden rounded-[2px] ${cardSize}`}
+          >
             <Image
               src={`${process.env.NEXT_PUBLIC_IMAGE_BASE_URL}/t/p/w300${item.poster_path}`}
               alt={title}

--- a/src/components/home/MediaCardSection.tsx
+++ b/src/components/home/MediaCardSection.tsx
@@ -4,13 +4,14 @@ import { TmdbMedia } from "@/types/tmdb";
 interface MediaCardSectionProps {
   title: string;
   items: TmdbMedia[];
+  size?: "small" | "large";
 }
 
-const MediaCardSection = ({ title, items }: MediaCardSectionProps) => {
+const MediaCardSection = ({ title, items, size = "small" }: MediaCardSectionProps) => {
   return (
     <div className="bg-black">
       <p className="text-heading-2 pb-3 pl-1 text-white">{title}</p>
-      <MediaCardCarousel items={items} />
+      <MediaCardCarousel items={items} size={size} />
     </div>
   );
 };

--- a/src/components/home/MediaCardSection.tsx
+++ b/src/components/home/MediaCardSection.tsx
@@ -1,0 +1,18 @@
+import MediaCardCarousel from "@/components/home/MediaCardCarousel";
+import { TmdbMedia } from "@/types/tmdb";
+
+interface MediaCardSectionProps {
+  title: string;
+  items: TmdbMedia[];
+}
+
+const MediaCardSection = ({ title, items }: MediaCardSectionProps) => {
+  return (
+    <div className="bg-black">
+      <p className="text-heading-2 pb-3 pl-1 text-white">{title}</p>
+      <MediaCardCarousel items={items} />
+    </div>
+  );
+};
+
+export default MediaCardSection;

--- a/src/components/home/NetflixOriginalsSection.tsx
+++ b/src/components/home/NetflixOriginalsSection.tsx
@@ -4,7 +4,7 @@ import { getNetflixOriginals } from "@/lib/apis/tmdb";
 const NetflixOriginalsSection = async () => {
   const data = await getNetflixOriginals();
 
-  return <MediaCardSection title="Netflix Originals" items={data.results} />;
+  return <MediaCardSection title="Netflix Originals" items={data.results} size="large" />;
 };
 
 export default NetflixOriginalsSection;

--- a/src/components/home/NetflixOriginalsSection.tsx
+++ b/src/components/home/NetflixOriginalsSection.tsx
@@ -1,0 +1,10 @@
+import MediaCardSection from "@/components/home/MediaCardSection";
+import { getNetflixOriginals } from "@/lib/apis/tmdb";
+
+const NetflixOriginalsSection = async () => {
+  const data = await getNetflixOriginals();
+
+  return <MediaCardSection title="Netflix Originals" items={data.results} />;
+};
+
+export default NetflixOriginalsSection;

--- a/src/lib/apis/tmdb.ts
+++ b/src/lib/apis/tmdb.ts
@@ -8,3 +8,13 @@ export const getTrendingAll = () =>
 // 홈페이지 Preview 섹션
 export const getPopularMovies = () =>
   tmdbClient<PopularMoviesResponse>("/movie/popular?language=ko-KR&page=1");
+
+// 홈페이지 Netflix Originals 섹션
+export const getNetflixOriginals = () =>
+  tmdbClient<PopularMoviesResponse>("/discover/tv?with_networks=213&language=ko-KR&page=1");
+// 홈페이지 Korea Movies 섹션
+export const getKoreanMovies = () =>
+  tmdbClient<PopularMoviesResponse>("/discover/movie?with_origin_country=KR&language=ko-KR&page=1");
+// 홈페이지 Animation 섹션
+export const getAnimationMovies = () =>
+  tmdbClient<PopularMoviesResponse>("/discover/movie?with_genres=16&language=ko-KR&page=1");

--- a/src/lib/apis/tmdb.ts
+++ b/src/lib/apis/tmdb.ts
@@ -1,5 +1,10 @@
 import { tmdbClient } from "@/lib/apis/tmdbClient";
-import { PopularMoviesResponse, TrendingAllResponse } from "@/types/tmdb";
+import {
+  MovieListResponse,
+  PopularMoviesResponse,
+  TrendingAllResponse,
+  TvListResponse,
+} from "@/types/tmdb";
 
 // 홈페이지 Top10 섹션
 export const getTrendingAll = () =>
@@ -11,10 +16,10 @@ export const getPopularMovies = () =>
 
 // 홈페이지 Netflix Originals 섹션
 export const getNetflixOriginals = () =>
-  tmdbClient<PopularMoviesResponse>("/discover/tv?with_networks=213&language=ko-KR&page=1");
+  tmdbClient<TvListResponse>("/discover/tv?with_networks=213&language=ko-KR&page=1");
 // 홈페이지 Korea Movies 섹션
 export const getKoreanMovies = () =>
-  tmdbClient<PopularMoviesResponse>("/discover/movie?with_origin_country=KR&language=ko-KR&page=1");
+  tmdbClient<MovieListResponse>("/discover/movie?with_origin_country=KR&language=ko-KR&page=1");
 // 홈페이지 Animation 섹션
 export const getAnimationMovies = () =>
-  tmdbClient<PopularMoviesResponse>("/discover/movie?with_genres=16&language=ko-KR&page=1");
+  tmdbClient<MovieListResponse>("/discover/movie?with_genres=16&language=ko-KR&page=1");

--- a/src/types/tmdb.ts
+++ b/src/types/tmdb.ts
@@ -40,3 +40,6 @@ export interface TmdbPaginatedResponse<T> {
 
 export type TrendingAllResponse = TmdbPaginatedResponse<TmdbMedia>;
 export type PopularMoviesResponse = TmdbPaginatedResponse<TmdbMovie>;
+
+export type MovieListResponse = TmdbPaginatedResponse<TmdbMovie>;
+export type TvListResponse = TmdbPaginatedResponse<TmdbTv>;


### PR DESCRIPTION
## 📢 PR 유형

어떤 변경 사항이 있었나요?

- [x] 새로운 기능 추가
- [ ] 버그 수정
- [ ] 코드에 영향을 주지 않는 변경사항(오타 수정, 탭 사이즈 변경, 변수명 변경)
- [ ] 코드 리팩토링
- [ ] 주석 추가 및 수정
- [ ] 문서 수정
- [ ] 빌드 부분 혹은 패키지 매니저 수정
- [ ] 파일 혹은 폴더명 수정
- [ ] 파일 혹은 폴더 삭제

---

## 📌 관련 이슈번호

- Closed #13 

---

## ✅ Key Changes
### API 레이어
- `getNetflixOriginals`, `getKoreanMovies`, `getAnimationMovies` API 함수 추가
- 카테고리별 TMDB `discover`으로 연결
- `MovieListResponse`, `TvListResponse` 타입 추가로 영화/TV 응답 타입 분리

### 홈페이지 섹션
- `MediaCardSection`, `MediaCardCarousel` 공통 섹션 및 캐러셀 컴포넌트 추가
- `page.tsx`에서 카테고리별 데이터 조회 후 섹션별로 전달하도록 연결
- `Netflix Originals`, `Animation Movies`, `Korean Movies` 섹션 추가

### UI/UX
- 직사각형 포스터 카드 UI 구현
- 기존 `useDragScroll`을 공통 캐러셀에 적용
- 이미지 `alt` 텍스트 분기 처리로 접근성 경고 수정
- 하단 포스터 섹션이 끝까지 보이도록 하단 여백 보정

---

## 📸 스크린샷 or 실행영상

https://github.com/user-attachments/assets/82103d30-fa2c-4082-a0c7-3fd62b77a072

---

## 🎸 기타 사항 or 추가 코멘트
