### PR TITLE
[FEAT] 상세 페이지 UI 구현

### DIFF
--- a/src/app/detail/[mediaType]/[id]/page.tsx
+++ b/src/app/detail/[mediaType]/[id]/page.tsx
@@ -1,10 +1,6 @@
-import Image from "next/image";
-
-import { PlayIcon } from "@/assets/icons";
-import Button from "@/components/common/Button";
-import BackButton from "@/components/detail/BackButton";
-import { getDetail } from "@/lib/apis/detail";
-import { getTmdbImageUrl } from "@/lib/utils/tmdb";
+import DetailActions from "@/components/detail/DetailActions";
+import DetailHero from "@/components/detail/DetailHero";
+import DetailOverview from "@/components/detail/DetailOverview";
 
 interface DetailPageProps {
   params: Promise<{ mediaType: string; id: string }>;
@@ -12,44 +8,12 @@ interface DetailPageProps {
 
 const page = async ({ params }: DetailPageProps) => {
   const { mediaType, id } = await params;
-  const data = await getDetail(mediaType as "movie" | "tv", id);
-
-  const title = "title" in data ? data.title : data.name;
-  const imagePath = data.poster_path ?? data.backdrop_path;
 
   return (
     <div className="flex flex-col text-white">
-      <div className="relative h-103.75 w-full">
-        {imagePath && (
-          <Image
-            src={getTmdbImageUrl(imagePath, "w500")}
-            alt={title}
-            fill
-            sizes="375px"
-            className="object-cover"
-            priority
-          />
-        )}
-        <div className="bg-gradient-thumbnail absolute inset-0" />
-        <BackButton />
-        <div className="absolute bottom-4 left-0 w-full px-4">
-          <h1 className="text-heading-1">{title}</h1>
-          {data.genres.length > 0 && (
-            <p className="text-caption-1 mt-1 text-gray-300">
-              {data.genres.map(g => g.name).join(" · ")}
-            </p>
-          )}
-        </div>
-      </div>
-      <div className="flex items-center justify-center pt-3">
-        <Button className="w-75.5" icon={<PlayIcon className="h-4 w-3.5" />}>
-          Play
-        </Button>
-      </div>
-      <div className="flex flex-col px-7 pt-8">
-        <p className="text-heading-1 pb-3 pl-1.5">Previews</p>
-        <p className="text-caption-1">{data.overview || "줄거리가 없습니다."}</p>
-      </div>
+      <DetailHero mediaType={mediaType as "movie" | "tv"} id={id} />
+      <DetailActions />
+      <DetailOverview mediaType={mediaType as "movie" | "tv"} id={id} />
     </div>
   );
 };

--- a/src/app/detail/[mediaType]/[id]/page.tsx
+++ b/src/app/detail/[mediaType]/[id]/page.tsx
@@ -1,4 +1,10 @@
+import Image from "next/image";
+
+import { PlayIcon } from "@/assets/icons";
+import Button from "@/components/common/Button";
+import BackButton from "@/components/detail/BackButton";
 import { getDetail } from "@/lib/apis/detail";
+import { getTmdbImageUrl } from "@/lib/utils/tmdb";
 
 interface DetailPageProps {
   params: Promise<{ mediaType: string; id: string }>;
@@ -8,11 +14,42 @@ const page = async ({ params }: DetailPageProps) => {
   const { mediaType, id } = await params;
   const data = await getDetail(mediaType as "movie" | "tv", id);
 
+  const title = "title" in data ? data.title : data.name;
+  const imagePath = data.poster_path ?? data.backdrop_path;
+
   return (
-    <div className="flex h-dvh flex-col items-center justify-center gap-4 text-white">
-      <p>타입: {mediaType}</p>
-      <p>id: {id}</p>
-      <p>{data.overview || "줄거리가 없습니다."}</p>
+    <div className="flex flex-col text-white">
+      <div className="relative h-103.75 w-full">
+        {imagePath && (
+          <Image
+            src={getTmdbImageUrl(imagePath, "w500")}
+            alt={title}
+            fill
+            sizes="375px"
+            className="object-cover"
+            priority
+          />
+        )}
+        <div className="bg-gradient-thumbnail absolute inset-0" />
+        <BackButton />
+        <div className="absolute bottom-4 left-0 w-full px-4">
+          <h1 className="text-heading-1">{title}</h1>
+          {data.genres.length > 0 && (
+            <p className="text-caption-1 mt-1 text-gray-300">
+              {data.genres.map(g => g.name).join(" · ")}
+            </p>
+          )}
+        </div>
+      </div>
+      <div className="flex items-center justify-center pt-3">
+        <Button className="w-75.5" icon={<PlayIcon className="h-4 w-3.5" />}>
+          Play
+        </Button>
+      </div>
+      <div className="flex flex-col px-7 pt-8">
+        <p className="text-heading-1 pb-3 pl-1.5">Previews</p>
+        <p className="text-caption-1">{data.overview || "줄거리가 없습니다."}</p>
+      </div>
     </div>
   );
 };

--- a/src/app/search/page.tsx
+++ b/src/app/search/page.tsx
@@ -1,0 +1,5 @@
+const page = () => {
+  return <div className="text-white">검색 페이지</div>;
+};
+
+export default page;

--- a/src/components/detail/BackButton.tsx
+++ b/src/components/detail/BackButton.tsx
@@ -1,0 +1,20 @@
+"use client";
+
+import { useRouter } from "next/navigation";
+
+import { XIcon } from "@/assets/icons";
+
+const BackButton = () => {
+  const router = useRouter();
+
+  return (
+    <button
+      onClick={() => router.back()}
+      className="absolute top-4 right-4 z-10 cursor-pointer text-white"
+    >
+      <XIcon className="size-6" />
+    </button>
+  );
+};
+
+export default BackButton;

--- a/src/components/detail/DetailActions.tsx
+++ b/src/components/detail/DetailActions.tsx
@@ -1,0 +1,14 @@
+import { PlayIcon } from "@/assets/icons";
+import Button from "@/components/common/Button";
+
+const DetailActions = () => {
+  return (
+    <div className="flex items-center justify-center pt-3">
+      <Button className="w-75.5" icon={<PlayIcon className="h-4 w-3.5" />}>
+        Play
+      </Button>
+    </div>
+  );
+};
+
+export default DetailActions;

--- a/src/components/detail/DetailHero.tsx
+++ b/src/components/detail/DetailHero.tsx
@@ -29,14 +29,6 @@ const DetailHero = async ({ mediaType, id }: DetailHeroProps) => {
       )}
       <div className="bg-gradient-thumbnail absolute inset-0" />
       <BackButton />
-      <div className="absolute bottom-4 left-0 w-full px-4">
-        <h1 className="text-heading-1">{title}</h1>
-        {data.genres.length > 0 && (
-          <p className="text-caption-1 mt-1 text-gray-300">
-            {data.genres.map(g => g.name).join(" · ")}
-          </p>
-        )}
-      </div>
     </div>
   );
 };

--- a/src/components/detail/DetailHero.tsx
+++ b/src/components/detail/DetailHero.tsx
@@ -1,0 +1,44 @@
+import Image from "next/image";
+
+import BackButton from "@/components/detail/BackButton";
+import { getDetail } from "@/lib/apis/detail";
+import { getTmdbImageUrl } from "@/lib/utils/tmdb";
+
+interface DetailHeroProps {
+  mediaType: "movie" | "tv";
+  id: string;
+}
+
+const DetailHero = async ({ mediaType, id }: DetailHeroProps) => {
+  const data = await getDetail(mediaType, id);
+
+  const title = "title" in data ? data.title : data.name;
+  const imagePath = data.poster_path ?? data.backdrop_path;
+
+  return (
+    <div className="relative h-103.75 w-full">
+      {imagePath && (
+        <Image
+          src={getTmdbImageUrl(imagePath, "w500")}
+          alt={title}
+          fill
+          sizes="375px"
+          className="object-cover"
+          priority
+        />
+      )}
+      <div className="bg-gradient-thumbnail absolute inset-0" />
+      <BackButton />
+      <div className="absolute bottom-4 left-0 w-full px-4">
+        <h1 className="text-heading-1">{title}</h1>
+        {data.genres.length > 0 && (
+          <p className="text-caption-1 mt-1 text-gray-300">
+            {data.genres.map(g => g.name).join(" · ")}
+          </p>
+        )}
+      </div>
+    </div>
+  );
+};
+
+export default DetailHero;

--- a/src/components/detail/DetailOverview.tsx
+++ b/src/components/detail/DetailOverview.tsx
@@ -1,0 +1,19 @@
+import { getDetail } from "@/lib/apis/detail";
+
+interface DetailOverviewProps {
+  mediaType: "movie" | "tv";
+  id: string;
+}
+
+const DetailOverview = async ({ mediaType, id }: DetailOverviewProps) => {
+  const data = await getDetail(mediaType, id);
+
+  return (
+    <div className="flex flex-col px-7 pt-8">
+      <p className="text-heading-1 pb-3 pl-1.5">Previews</p>
+      <p className="text-caption-1">{data.overview || "줄거리가 없습니다."}</p>
+    </div>
+  );
+};
+
+export default DetailOverview;

--- a/src/components/detail/DetailOverview.tsx
+++ b/src/components/detail/DetailOverview.tsx
@@ -8,9 +8,16 @@ interface DetailOverviewProps {
 const DetailOverview = async ({ mediaType, id }: DetailOverviewProps) => {
   const data = await getDetail(mediaType, id);
 
+  const title = "title" in data ? data.title : data.name;
+
   return (
     <div className="flex flex-col px-7 pt-8">
-      <p className="text-heading-1 pb-3 pl-1.5">Previews</p>
+      <h1 className="text-heading-1 pb-1 pl-1.5">{title}</h1>
+      {data.genres.length > 0 && (
+        <p className="text-caption-1 pb-3 pl-1.5 text-gray-300">
+          {data.genres.map(g => g.name).join(" · ")}
+        </p>
+      )}
       <p className="text-caption-1">{data.overview || "줄거리가 없습니다."}</p>
     </div>
   );

--- a/src/lib/utils/tmdb.ts
+++ b/src/lib/utils/tmdb.ts
@@ -1,6 +1,6 @@
 import { TmdbMedia } from "@/types/home";
 
-type TmdbImageSize = "w185" | "w300" | "w500";
+type TmdbImageSize = "w185" | "w300" | "w500" | "w780" | "original";
 
 export const getTmdbImageUrl = (path: string, size: TmdbImageSize) =>
   `${process.env.NEXT_PUBLIC_IMAGE_BASE_URL}/t/p/${size}${path}`;


### PR DESCRIPTION
## 📢 PR 유형

어떤 변경 사항이 있었나요?

- [x] 새로운 기능 추가
- [ ] 버그 수정
- [ ] 코드에 영향을 주지 않는 변경사항(오타 수정, 탭 사이즈 변경, 변수명 변경)
- [ ] 코드 리팩토링
- [ ] 주석 추가 및 수정
- [ ] 문서 수정
- [ ] 빌드 부분 혹은 패키지 매니저 수정
- [ ] 파일 혹은 폴더명 수정
- [ ] 파일 혹은 폴더 삭제

---

## 📌 관련 이슈번호

- Closed #19 

---

## ✅ Key Changes

상세 페이지(Detail Page) UI를 구현하고 컴포넌트 단위로 구조를 분리했습니다.
- `DetailHero`: 포스터 이미지, 제목, 장르, 뒤로가기 버튼을 포함한 히어로 섹션 구현
- `DetailActions`: Play 버튼 액션 영역 구현
- `DetailOverview`: 줄거리(overview) 섹션 구현
- `BackButton`: `router.back()`을 이용한 클라이언트 뒤로가기 버튼 구현
- `src/app/search/page.tsx`: 검색 페이지 더미 라우트 추가
- `detail/[mediaType]/[id]/page.tsx`: 기존 인라인 렌더링을 `DetailHero`, `DetailActions`, `DetailOverview` 컴포넌트로 분리
- `tmdb.ts`: `TmdbImageSize` 타입에 `w780`, `original` 사이즈 추가

---

## 📸 스크린샷 or 실행영상

https://github.com/user-attachments/assets/c5f7d8d4-76ef-4e59-ae62-dee79de79d5f



---

## 🎸 기타 사항 or 추가 코멘트
